### PR TITLE
[codex] Export measurement types for dimensions

### DIFF
--- a/src/acceleration/dimension.ts
+++ b/src/acceleration/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {AccelerationSymbol} from "./symbols";
 
+export type Acceleration = Measurement<AccelerationSymbol>;
 export const acceleration = dimension<AccelerationSymbol>({
   "m/s²": linearConversion(1.0),
   "g": linearConversion(9.81)

--- a/src/angle/dimension.ts
+++ b/src/angle/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {AngleSymbol} from "./symbols";
 
+export type Angle = Measurement<AngleSymbol>;
 export const angle = dimension<AngleSymbol>({
   "°": linearConversion(1),
   "ʹ": linearConversion(1 / 60),

--- a/src/area/dimension.ts
+++ b/src/area/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {AreaSymbol} from "./symbols";
 
+export type Area = Measurement<AreaSymbol>;
 export const area = dimension<AreaSymbol>({
   "Mm²": linearConversion(1e12),
   "km²": linearConversion(1000000.0),

--- a/src/concentration-mass/dimension.ts
+++ b/src/concentration-mass/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {ConcentrationMassSymbol} from "./symbols";
 
+export type ConcentrationMass = Measurement<ConcentrationMassSymbol>;
 export const concentrationMass = dimension<ConcentrationMassSymbol>({
   "g/L": linearConversion(1),
   "mg/dL": linearConversion(0.01)

--- a/src/dispersion/dimension.ts
+++ b/src/dispersion/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {DispersionSymbol} from "./symbols";
 
+export type Dispersion = Measurement<DispersionSymbol>;
 export const dispersion = dimension<DispersionSymbol>({
   "ppm": linearConversion(1),
   "ppb": linearConversion(1e-3),

--- a/src/duration/dimension.ts
+++ b/src/duration/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {DurationSymbol} from "./symbols";
 
+export type Duration = Measurement<DurationSymbol>;
 export const duration = dimension<DurationSymbol>({
   "sec": linearConversion(1),
   "min": linearConversion(60),

--- a/src/electric-charge/dimension.ts
+++ b/src/electric-charge/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {ElectricChargeSymbol} from "./symbols";
 
+export type ElectricCharge = Measurement<ElectricChargeSymbol>;
 export const electricCharge = dimension<ElectricChargeSymbol>({
   "C": linearConversion(1.0),
   "MAh": linearConversion(3.6e9),

--- a/src/electric-current/dimension.ts
+++ b/src/electric-current/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {ElectricCurrentSymbol} from "./symbols";
 
+export type ElectricCurrent = Measurement<ElectricCurrentSymbol>;
 export const electricCurrent = dimension<ElectricCurrentSymbol>({
   "MA": linearConversion(1000000.0),
   "kA": linearConversion(1000.0),

--- a/src/electric-potential-difference/dimension.ts
+++ b/src/electric-potential-difference/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {ElectricPotentialDifferenceSymbol} from "./symbols";
 
+export type ElectricPotentialDifference = Measurement<ElectricPotentialDifferenceSymbol>;
 export const electricPotentialDifference = dimension<ElectricPotentialDifferenceSymbol>({
   "MV": linearConversion(1000000.0),
   "kV": linearConversion(1000.0),

--- a/src/electric-resistance/dimension.ts
+++ b/src/electric-resistance/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {ElectricResistanceSymbol} from "./symbols";
 
+export type ElectricResistance = Measurement<ElectricResistanceSymbol>;
 export const electricResistance = dimension<ElectricResistanceSymbol>({
   "MΩ": linearConversion(1000000.0),
   "kΩ": linearConversion(1000.0),

--- a/src/energy/dimension.ts
+++ b/src/energy/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {EnergySymbol} from "./symbols";
 
+export type Energy = Measurement<EnergySymbol>;
 export const energy = dimension<EnergySymbol>({
   "kJ": linearConversion(1000.0),
   "J": linearConversion(1.0),

--- a/src/frequency/dimension.ts
+++ b/src/frequency/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {FrequencySymbol} from "./symbols";
 
+export type Frequency = Measurement<FrequencySymbol>;
 export const frequency = dimension<FrequencySymbol>({
   "THz": linearConversion(1e12),
   "GHz": linearConversion(1e9),

--- a/src/illuminance/dimension.ts
+++ b/src/illuminance/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {IlluminanceSymbol} from "./symbols";
 
+export type Illuminance = Measurement<IlluminanceSymbol>;
 export const illuminance = dimension<IlluminanceSymbol>({
   "lx": linearConversion(1.0)
 });

--- a/src/information/dimension.ts
+++ b/src/information/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {InformationSymbol} from "./symbols";
 
+export type Information = Measurement<InformationSymbol>;
 export const information = dimension<InformationSymbol>({
   "b": linearConversion(1),
   "B": linearConversion(8),

--- a/src/length/dimension.ts
+++ b/src/length/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {LengthSymbol} from "./symbols";
 
+export type Length = Measurement<LengthSymbol>;
 export const length = dimension<LengthSymbol>({
   "Mm": linearConversion(1E6),
   "kM": linearConversion(1E3),

--- a/src/mass/dimension.ts
+++ b/src/mass/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {MassSymbol} from "./symbols";
 
+export type Mass = Measurement<MassSymbol>;
 export const mass = dimension<MassSymbol>({
   "kg": linearConversion(1.0),
   "g": linearConversion(0.001),

--- a/src/power/dimension.ts
+++ b/src/power/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {PowerSymbol} from "./symbols";
 
+export type Power = Measurement<PowerSymbol>;
 export const power = dimension<PowerSymbol>({
   "TW": linearConversion(1e12),
   "GW": linearConversion(1e9),

--- a/src/pressure/dimension.ts
+++ b/src/pressure/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {PressureSymbol} from "./symbols";
 
+export type Pressure = Measurement<PressureSymbol>;
 export const pressure = dimension<PressureSymbol>({
   "N/m²": linearConversion(1.0),
   "GPa": linearConversion(1e9),

--- a/src/speed/dimension.ts
+++ b/src/speed/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {SpeedSymbol} from "./symbols";
 
+export type Speed = Measurement<SpeedSymbol>;
 export const speed = dimension<SpeedSymbol>({
   "m/s": linearConversion(1.0),
   "km/h": linearConversion(0.277778),

--- a/src/temperature/dimension.ts
+++ b/src/temperature/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {TemperatureSymbol} from "./symbols";
 
+export type Temperature = Measurement<TemperatureSymbol>;
 export const temperature = dimension<TemperatureSymbol>({
   "K": linearConversion(1, 0),
   "°C": linearConversion(1.0, 273.15),

--- a/src/volume/dimension.ts
+++ b/src/volume/dimension.ts
@@ -1,6 +1,7 @@
-import {linearConversion, dimension} from "../dimension";
+import {linearConversion, dimension, type Measurement} from "../dimension";
 import {VolumeSymbol} from "./symbols";
 
+export type Volume = Measurement<VolumeSymbol>;
 export const volume = dimension<VolumeSymbol>({
   "ML": linearConversion(1000000.0),
   "kL": linearConversion(1000.0),


### PR DESCRIPTION
## What changed

- Added exported measurement type aliases for every concrete dimension module.
- Kept the aliases type-only, including the existing Length change.

## Validation

- pnpm run typecheck
- pnpm run test