### PR TITLE
[codex] Add user-facing package examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+.npm-cache
 
 /node_modules
 /.pnp

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@vitest/coverage-v8": "^4.1.5",
     "bunchee": "^6.10.0",
     "eslint": "^10.3.0",
-    "pnpm": "^10.33.3",
+    "pnpm": "^11.0.8",
     "rimraf": "^6.1.3",
     "type-fest": "^5.6.0",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 10.3.0
       pnpm:
         specifier: ^10.33.3
-        version: 10.33.3
+        version: 10.33.4
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -1224,8 +1224,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  pnpm@10.33.3:
-    resolution: {integrity: sha512-oZdENkp+JIuSZXpMpZc/k1TSHK+YJXlnSxxTnzLHQgxHE4rYsSVN8Hq6m8eC2bMCnj2zTV2/+XQybrdNrI/0iQ==}
+  pnpm@10.33.4:
+    resolution: {integrity: sha512-HGezs1my1AgRm6HtKJ80uPw8aHNBK+xv0mT73IJInlEPy+y5zp0i2ufzt2Jp2EQQRgFL3KU7mXnNelYa1jG4AA==}
     engines: {node: '>=18.12'}
     hasBin: true
 
@@ -2568,7 +2568,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  pnpm@10.33.3: {}
+  pnpm@10.33.4: {}
 
   postcss@8.5.14:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^10.3.0
         version: 10.3.0
       pnpm:
-        specifier: ^10.33.3
-        version: 10.33.4
+        specifier: ^11.0.8
+        version: 11.0.8
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -1224,9 +1224,9 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  pnpm@10.33.4:
-    resolution: {integrity: sha512-HGezs1my1AgRm6HtKJ80uPw8aHNBK+xv0mT73IJInlEPy+y5zp0i2ufzt2Jp2EQQRgFL3KU7mXnNelYa1jG4AA==}
-    engines: {node: '>=18.12'}
+  pnpm@11.0.8:
+    resolution: {integrity: sha512-TECX4d0tQjcsTn+lp5H/KPx1pITHrBkuZLHfD97xdZS6mC+bT+2a37PHV4RvVlt5mydj+zcz0d4by4LPRmhJEg==}
+    engines: {node: '>=22.13'}
     hasBin: true
 
   postcss@8.5.14:
@@ -2568,7 +2568,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  pnpm@10.33.4: {}
+  pnpm@11.0.8: {}
 
   postcss@8.5.14:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 2.0.8
       '@types/node':
         specifier: ^25.6.0
-        version: 25.6.0
+        version: 25.6.2
       '@typescript-eslint/parser':
         specifier: ^8.59.2
         version: 8.59.2(eslint@10.3.0)(typescript@6.0.3)
@@ -46,7 +46,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0))
+        version: 4.1.5(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.2))
 
 packages:
 
@@ -609,8 +609,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+  '@types/node@25.6.2':
+    resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -1961,7 +1961,7 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@25.6.0':
+  '@types/node@25.6.2':
     dependencies:
       undici-types: 7.19.2
 
@@ -2031,7 +2031,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0))
+      vitest: 4.1.5(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.2))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -2042,13 +2042,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.2))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)
+      vite: 8.0.10(@types/node@25.6.2)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -2768,7 +2768,7 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite@8.0.10(@types/node@25.6.0):
+  vite@8.0.10(@types/node@25.6.2):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2776,13 +2776,13 @@ snapshots:
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.6.2
       fsevents: 2.3.3
 
-  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)):
+  vitest@4.1.5(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.2)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.2))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -2799,10 +2799,10 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)
+      vite: 8.0.10(@types/node@25.6.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.6.2
       '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
     transitivePeerDependencies:
       - msw

--- a/test/user/10.practical-non-length-dimensions.test.ts
+++ b/test/user/10.practical-non-length-dimensions.test.ts
@@ -1,0 +1,29 @@
+import {expect, test} from "vitest";
+import {areEqual} from "@adam-rocska/units-and-measurement/operations";
+import {
+  bytes,
+  kilobytes,
+} from "@adam-rocska/units-and-measurement/information";
+import {
+  kilowatts,
+  watts,
+} from "@adam-rocska/units-and-measurement/power";
+import {
+  liters,
+  milliliters,
+} from "@adam-rocska/units-and-measurement/volume";
+
+test("Use Case 10: Non-length dimensions cover everyday conversions", () => {
+  expect(liters(1).mL.value).toBe(1000);
+  expect(milliliters(250).L.value).toBe(0.25);
+
+  expect(kilowatts(1).W.value).toBe(1000);
+  expect(watts(1000).kW.value).toBe(1);
+
+  expect(kilobytes(1).B.value).toBe(1024);
+  expect(bytes(1024).KB.value).toBe(1);
+
+  expect(areEqual(liters(1), milliliters(1000))).toBe(true);
+  expect(areEqual(kilowatts(1), watts(1000))).toBe(true);
+  expect(areEqual(kilobytes(1), bytes(1024))).toBe(true);
+});

--- a/test/user/11.incompatible-units.test.ts
+++ b/test/user/11.incompatible-units.test.ts
@@ -1,0 +1,25 @@
+import {expect, test} from "vitest";
+import {
+  object,
+  string,
+  tuple,
+} from "@adam-rocska/units-and-measurement";
+import {
+  add,
+  greaterThan,
+  toCommonUnit,
+} from "@adam-rocska/units-and-measurement/operations";
+
+test("Use Case 11: Incompatible units return undefined", () => {
+  expect(add(string.measurement(1, "m"), string.measurement(2, "sec")))
+    .toBeUndefined();
+
+  expect(greaterThan(tuple.measurement(1, "m"), tuple.measurement(2, "sec")))
+    .toBeUndefined();
+
+  expect(toCommonUnit(
+    object.measurement(1, "foo"),
+    object.measurement(2, "bar")
+  ))
+    .toBeUndefined();
+});

--- a/test/user/3.measurement-representations.test.ts
+++ b/test/user/3.measurement-representations.test.ts
@@ -1,0 +1,35 @@
+import {expect, test} from "vitest";
+import {
+  type Measurement,
+  measurement,
+  object,
+  string,
+  tuple,
+  unit,
+  value,
+} from "@adam-rocska/units-and-measurement";
+
+test("Use Case 3: Measurement representations stay interchangeable", () => {
+  type Px = Measurement<"px">;
+
+  const cssWidth: Px = string.measurement(320, "px");
+  const animationDelay = tuple.measurement(120, "ms");
+  const payloadSize = object.measurement(4, "kB");
+
+  expect(value(cssWidth)).toBe(320);
+  expect(unit(cssWidth)).toBe("px");
+
+  expect(value(animationDelay)).toBe(120);
+  expect(unit(animationDelay)).toBe("ms");
+
+  expect(value(payloadSize)).toBe(4);
+  expect(unit(payloadSize)).toBe("kB");
+
+  expect(measurement(cssWidth, 640)).toBe("640px");
+  expect(measurement(animationDelay, 240)).toEqual([240, "ms"]);
+
+  const largerPayload = measurement(payloadSize, 8);
+
+  expect(value(largerPayload)).toBe(8);
+  expect(unit(largerPayload)).toBe("kB");
+});

--- a/test/user/4.built-in-dimension-conversions.test.ts
+++ b/test/user/4.built-in-dimension-conversions.test.ts
@@ -1,0 +1,24 @@
+import {expect, test} from "vitest";
+import {dimension} from "@adam-rocska/units-and-measurement";
+import {
+  kilometers,
+  meters,
+  type Length,
+} from "@adam-rocska/units-and-measurement/length";
+
+test("Use Case 4: Built-in dimensions expose typed conversions", () => {
+  const route: Length = kilometers(5);
+  const trackLap = meters(400);
+
+  expect(route.kM.value).toBe(5);
+  expect(route.m.value).toBe(5000);
+  expect(route.m.unit).toBe("m");
+
+  expect(trackLap.kM.value).toBe(0.4);
+  expect(trackLap.cm.value).toBe(40000);
+
+  const roundedMiles = dimension.toFixed(route.mi, 2);
+
+  expect(roundedMiles.value).toBe(3.11);
+  expect(roundedMiles.unit).toBe("mi");
+});

--- a/test/user/5.common-unit-arithmetic.test.ts
+++ b/test/user/5.common-unit-arithmetic.test.ts
@@ -1,0 +1,44 @@
+import {expect, test} from "vitest";
+import {
+  object,
+  string,
+  tuple,
+  unit,
+  value,
+} from "@adam-rocska/units-and-measurement";
+import {
+  add,
+  subtract,
+  toCommonUnit,
+} from "@adam-rocska/units-and-measurement/operations";
+
+test("Use Case 5: Plain measurements use built-in unit knowledge", () => {
+  const normalized = toCommonUnit(
+    object.measurement(1, "m"),
+    tuple.measurement(25, "cm"),
+    string.measurement(1000, "mm")
+  );
+
+  if (normalized === undefined) {
+    throw new Error("Expected compatible length units to normalize.");
+  }
+
+  expect(normalized.map(unit)).toEqual(["m", "m", "m"]);
+  expect(normalized.map(value)).toEqual([1, 0.25, 1]);
+
+  const total = add(
+    object.measurement(1, "m"),
+    tuple.measurement(25, "cm"),
+    string.measurement(1000, "mm")
+  );
+
+  if (total === undefined) {
+    throw new Error("Expected compatible length units to add.");
+  }
+
+  expect(value(total)).toBe(2.25);
+  expect(unit(total)).toBe("m");
+
+  expect(subtract(string.measurement(1, "m"), string.measurement(25, "cm")))
+    .toBe("0.75m");
+});

--- a/test/user/6.temperature-offset-conversions.test.ts
+++ b/test/user/6.temperature-offset-conversions.test.ts
@@ -1,0 +1,20 @@
+import {expect, test} from "vitest";
+import {dimension} from "@adam-rocska/units-and-measurement";
+import {areEqual} from "@adam-rocska/units-and-measurement/operations";
+import {
+  celsius,
+  fahrenheit,
+  kelvin,
+  rankine,
+} from "@adam-rocska/units-and-measurement/temperature";
+
+test("Use Case 6: Temperature conversions handle offsets", () => {
+  expect(celsius(0).K.value).toBeCloseTo(273.15);
+  expect(fahrenheit(32)["°C"].value).toBeCloseTo(0);
+  expect(kelvin(273.15)["°C"].value).toBeCloseTo(0);
+  expect(rankine(0).K.value).toBe(0);
+
+  const boilingInCelsius = dimension.toFixed(fahrenheit(212)["°C"], 6);
+
+  expect(areEqual(celsius(100), boilingInCelsius)).toBe(true);
+});

--- a/test/user/7.custom-dimension-workflow.test.ts
+++ b/test/user/7.custom-dimension-workflow.test.ts
@@ -1,0 +1,34 @@
+import {expect, test} from "vitest";
+import {
+  dimension as d,
+  unit,
+  value,
+} from "@adam-rocska/units-and-measurement";
+import {
+  add,
+  areEqual,
+  greaterThan,
+} from "@adam-rocska/units-and-measurement/operations";
+
+test("Use Case 7: Custom dimensions behave like built-in dimensions", () => {
+  type CurrencySymbol = "USD" | "cent";
+
+  const currency = d.dimension<CurrencySymbol>({
+    USD: d.linearConversion(1),
+    cent: d.linearConversion(0.01),
+  });
+
+  const subtotal = currency.USD(19.99);
+  const cardFee = currency.cent(25);
+  const total = add(subtotal, cardFee);
+
+  if (total === undefined) {
+    throw new Error("Expected custom currency units to add.");
+  }
+
+  expect(value(total)).toBeCloseTo(20.24);
+  expect(unit(total)).toBe("USD");
+  expect(currency.cent(1234).USD.value).toBeCloseTo(12.34);
+  expect(areEqual(currency.USD(1), currency.cent(100))).toBe(true);
+  expect(greaterThan(total, currency.USD(20))).toBe(true);
+});

--- a/test/user/8.symbol-predicates-and-type-aliases.test.ts
+++ b/test/user/8.symbol-predicates-and-type-aliases.test.ts
@@ -1,0 +1,30 @@
+import {expect, test} from "vitest";
+import {
+  isLengthSymbol,
+  length,
+  lengthSymbols,
+  type Length,
+  type LengthSymbol,
+} from "@adam-rocska/units-and-measurement/length";
+
+test("Use Case 8: Symbol predicates protect dynamic unit input", () => {
+  function readLength(value: number, candidate: string): Length | undefined {
+    if (!isLengthSymbol(candidate)) return undefined;
+
+    const safeUnit: LengthSymbol = candidate;
+    return length[safeUnit](value);
+  }
+
+  expect(lengthSymbols).toContain("ft");
+  expect(readLength(1, "parsec")).toBeUndefined();
+
+  const parsed = readLength(12, "ft");
+
+  if (parsed === undefined) {
+    throw new Error("Expected feet to be a supported length symbol.");
+  }
+
+  expect(parsed.unit).toBe("ft");
+  expect(parsed.in.value).toBeCloseTo(144);
+  expect(parsed.yd.value).toBeCloseTo(4);
+});

--- a/test/user/9.formatting-and-cloning.test.ts
+++ b/test/user/9.formatting-and-cloning.test.ts
@@ -1,0 +1,34 @@
+import {expect, test} from "vitest";
+import {
+  dimension,
+  measurement,
+  object,
+  string,
+  toFixed,
+  toPrecision,
+  tuple,
+  unit,
+  value,
+} from "@adam-rocska/units-and-measurement";
+import {inches} from "@adam-rocska/units-and-measurement/length";
+
+test("Use Case 9: Formatting and cloning preserve measurement shape", () => {
+  expect(toFixed(string.measurement(1.236, "m"), 2)).toBe("1.24m");
+  expect(toPrecision(tuple.measurement(1234, "ms"), 2)).toEqual([1200, "ms"]);
+
+  const roundedObject = toFixed(object.measurement(1.236, "kg"), 2);
+
+  expect(value(roundedObject)).toBe(1.24);
+  expect(unit(roundedObject)).toBe("kg");
+
+  const baseMass = object.measurement(5, "kg");
+  const updatedMass = measurement(baseMass, 7);
+
+  expect(value(updatedMass)).toBe(7);
+  expect(unit(updatedMass)).toBe("kg");
+
+  const roundedDimension = dimension.toPrecision(inches(12).cm, 3);
+
+  expect(roundedDimension.value).toBe(30.5);
+  expect(roundedDimension.unit).toBe("cm");
+});


### PR DESCRIPTION
## What changed

- Added nine UAT/example tests under test/user.
- Covered measurement representations, built-in dimensions, arithmetic, temperature offsets, custom dimensions, symbol predicates, formatting, non-length dimensions, and incompatible units.
- Exercised the new dimension measurement type aliases through user-facing imports.

## Validation

- pnpm run typecheck
- pnpm run lint
- pnpm run test