### PR TITLE
Add measurement proportion operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,18 +77,20 @@ const asObject = object.measurement(12, "px");
 console.log(value(asString), unit(asTuple), asObject.value);
 ```
 
-Use the operations submodule for arithmetic, comparison, and common-unit
-conversion:
+Use the operations submodule for arithmetic, comparison, proportionality, and
+common-unit conversion:
 
 ```typescript
-import {add, greaterThan, toCommonUnit} from "@adam-rocska/units-and-measurement/operations";
+import {add, greaterThan, proportion, toCommonUnit} from "@adam-rocska/units-and-measurement/operations";
 import {centimeters, meters} from "@adam-rocska/units-and-measurement/length";
 
 const total = add(meters(2), centimeters(50));
 const normalized = toCommonUnit(meters(2), centimeters(50));
+const ratio = proportion(meters(2), centimeters(50));
 
 console.log(total);
 console.log(normalized);
+console.log(ratio);
 console.log(greaterThan(meters(2), centimeters(50)));
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -90,6 +90,27 @@ console.log(value(doubled), value(halved));
 `divide`, `power`, `root`, and `logarithm` operate on one measurement and one
 number.
 
+## Proportions
+
+`proportion` returns the numeric ratio between two measurements. Measurements
+with the same unit are compared directly. Measurements with different units are
+converted only when at least one input is a dimension measurement.
+
+```typescript
+import {string} from "@adam-rocska/units-and-measurement";
+import {proportion} from "@adam-rocska/units-and-measurement/operations";
+import {centimeters, meters} from "@adam-rocska/units-and-measurement/length";
+
+console.log(proportion(string.measurement(640, "px"), string.measurement(320, "px")));
+console.log(proportion(meters(2), centimeters(50)));
+console.log(proportion(meters(2), string.measurement(50, "cm")));
+console.log(proportion(string.measurement(1, "m"), string.measurement(100, "cm")));
+```
+
+The final example returns `undefined`: plain measurements with different units
+are not converted for `proportion` unless a dimension measurement provides the
+conversion context.
+
 ## Comparisons
 
 Comparison helpers also convert compatible measurements first. They return

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -2,4 +2,5 @@ export * from "./arithmetic-operation";
 export * from "./arithmetics";
 export * from "./comparisons";
 export * from "./logical-operation";
+export * from "./proportion";
 export * from "./to-common-unit";

--- a/src/operations/proportion.ts
+++ b/src/operations/proportion.ts
@@ -1,0 +1,39 @@
+import * as dimension from "../dimension";
+import {type Measurement} from "../measurement";
+import {unit} from "../unit";
+import {value} from "../value";
+import {toCommonUnit} from "./to-common-unit";
+
+/**
+ * Returns the ratio between two compatible measurements.
+ *
+ * Measurements with the same unit are compared directly. Measurements with
+ * different units are converted only when at least one input is a dimension
+ * measurement.
+ */
+export function proportion<
+  NumeratorUnit extends string,
+  DenominatorUnit extends string
+>(
+  numerator: Measurement<NumeratorUnit>,
+  denominator: Measurement<DenominatorUnit>
+): number | undefined {
+  const numeratorUnit: string = unit(numerator);
+  const denominatorUnit: string = unit(denominator);
+
+  if (numeratorUnit === denominatorUnit) {
+    return value(numerator) / value(denominator);
+  }
+
+  if (!dimension.isMeasurement(numerator) && !dimension.isMeasurement(denominator)) {
+    return undefined;
+  }
+
+  const commonUnit = toCommonUnit<NumeratorUnit | DenominatorUnit>(
+    numerator,
+    denominator
+  );
+  if (commonUnit === undefined) return undefined;
+
+  return value(commonUnit[0]!) / value(commonUnit[1]!);
+}

--- a/test/unit/operations/proportion.test.ts
+++ b/test/unit/operations/proportion.test.ts
@@ -1,0 +1,59 @@
+import {describe, expect, it} from "vitest";
+import {
+  object,
+  string,
+  tuple,
+} from "@adam-rocska/units-and-measurement";
+import {proportion} from "@adam-rocska/units-and-measurement/operations";
+import {
+  centimeters,
+  meters,
+} from "@adam-rocska/units-and-measurement/length";
+import {seconds} from "@adam-rocska/units-and-measurement/duration";
+
+describe("proportion", () => {
+  it("should return the ratio for string measurements with the same unit", () => {
+    expect(proportion(string.measurement(10, "px"), string.measurement(5, "px")))
+      .toBe(2);
+  });
+
+  it("should return the ratio for tuple measurements with the same unit", () => {
+    expect(proportion(tuple.measurement(15, "rem"), tuple.measurement(3, "rem")))
+      .toBe(5);
+  });
+
+  it("should return the ratio for object measurements with the same unit", () => {
+    expect(proportion(object.measurement(12, "kg"), object.measurement(4, "kg")))
+      .toBe(3);
+  });
+
+  it("should preserve JavaScript division semantics for zero denominators", () => {
+    expect(proportion(string.measurement(1, "px"), string.measurement(0, "px")))
+      .toBe(Infinity);
+  });
+
+  it("should return undefined for plain measurements with different units", () => {
+    expect(proportion(string.measurement(1, "m"), string.measurement(100, "cm")))
+      .toBeUndefined();
+  });
+
+  it("should convert when the numerator is a dimension measurement", () => {
+    expect(proportion(meters(2), string.measurement(50, "cm")))
+      .toBe(4);
+  });
+
+  it("should convert when the denominator is a dimension measurement", () => {
+    expect(proportion(tuple.measurement(50, "cm"), meters(2)))
+      .toBe(0.25);
+  });
+
+  it("should convert when both inputs are dimension measurements", () => {
+    expect(proportion(meters(2), centimeters(50)))
+      .toBe(4);
+  });
+
+  it("should return undefined for incompatible dimension measurements", () => {
+    expect(proportion(meters(1), seconds(1)))
+      .toBeUndefined();
+  });
+});

--- a/test/user/12.proportions.test.ts
+++ b/test/user/12.proportions.test.ts
@@ -1,0 +1,49 @@
+import {expect, test} from "vitest";
+import {
+  object,
+  string,
+  tuple,
+} from "@adam-rocska/units-and-measurement";
+import {proportion} from "@adam-rocska/units-and-measurement/operations";
+import {
+  centimeters,
+  inches,
+  meters,
+} from "@adam-rocska/units-and-measurement/length";
+import {
+  celsius,
+  fahrenheit,
+} from "@adam-rocska/units-and-measurement/temperature";
+import {
+  liters,
+  milliliters,
+} from "@adam-rocska/units-and-measurement/volume";
+
+test("Use Case 12: Measurements can be compared as proportions", () => {
+  expect(proportion(string.measurement(640, "px"), string.measurement(320, "px")))
+    .toBe(2);
+
+  expect(proportion(tuple.measurement(45, "min"), tuple.measurement(15, "min")))
+    .toBe(3);
+
+  expect(proportion(object.measurement(7.5, "kg"), object.measurement(2.5, "kg")))
+    .toBe(3);
+
+  expect(proportion(inches(11), centimeters(13.97)))
+    .toBeCloseTo(2);
+
+  expect(proportion(meters(2), string.measurement(50, "cm")))
+    .toBe(4);
+
+  expect(proportion(tuple.measurement(250, "mL"), liters(1)))
+    .toBe(0.25);
+
+  expect(proportion(liters(1), milliliters(250)))
+    .toBe(4);
+
+  expect(proportion(fahrenheit(212), celsius(100)))
+    .toBeCloseTo(1);
+
+  expect(proportion(string.measurement(1, "m"), string.measurement(100, "cm")))
+    .toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- add `proportion` to the operations API
- compare same-unit measurements directly
- convert compatible units when a dimension measurement provides context
- document usage and add a UAT example suite

## Validation
- `pnpm exec vitest run test/unit/operations/proportion.test.ts --coverage --coverage.include=src/operations/proportion.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`
- `pnpm run check`